### PR TITLE
add error checking to getTeamInfo

### DIFF
--- a/server.js
+++ b/server.js
@@ -86,6 +86,11 @@ module.exports = {
 		var teamInfoJson = {};
 
 		request(teamJsonURL, function (error, response) {
+			if(error) {
+				console.log('Error obtaining team info');
+				callback({ status: 500, message: "There was an error trying to make your request" });
+			}
+
 			teamInfoJson = JSON.parse(response.body);
 			teamInfoJson.avatarImageURL = 'http:' + teamInfoJson.avatarImageURL;
 			teamInfoJson.teamURL = teamUrl;


### PR DESCRIPTION
Error occurs and is unchecked causing:

```
Error parsing teamInfo URL
 /path/node_modules/extra-life-api/server.js:89
       teamInfoJson = JSON.parse(response.body);
                                         ^

 TypeError: Cannot read property 'body' of undefined
     at Request._callback (/path/node_modules/extra-life-api/server.js:89:38)
     at self.callback (/path/node_modules/extra-life-api/node_modules/request/uest.js:198:22)
     at emitOne (events.js:115:13)
     at Request.emit (events.js:210:7)
     at Request.onRequestError (/path/node_modules/extra-life-api/node_modules/uest/request.js:877:8)
     at emitOne (events.js:115:13)
     at ClientRequest.emit (events.js:210:7)
     at TLSSocket.socketErrorListener (_http_client.js:401:9)
     at emitOne (events.js:115:13)
     at TLSSocket.emit (events.js:210:7)
     at emitErrorNT (internal/streams/destroy.js:64:8)
     at _combinedTickCallback (internal/process/next_tick.js:138:11)
     at process._tickCallback (internal/process/next_tick.js:180:9)
```