### PR TITLE
fix: Correct Pagination Increments

### DIFF
--- a/src/helpers/api-paths.ts
+++ b/src/helpers/api-paths.ts
@@ -5,7 +5,7 @@ const pageOffset = (limit: number, page: number): number => {
         return 1;
     }
 
-    return limit * page;
+    return limit * (page - 1);
 };
 
 export const apiPaths = {


### PR DESCRIPTION
As the code is currently written, pagination sets the offset to:
- 1 (for page 1)
- 200 (for page 2)
- 300 (for page 3)
- etc.

As you can see, this skips the real second page (100 offset).  It can easily be fixed by subtracting 1 from the page before multiplying by the limit.