### PR TITLE
Adding fail on cache-hit feature

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -6,6 +6,10 @@ const demoTeam = 60878;
 getUserInfo(demoUser)
   .then((data) => {
     console.log(data);
+    return getUserInfo(demoUser, data.cacheTag);
+  })
+  .then((data) => {
+    console.log(data);
   })
   .catch((err) => {
     console.error(err);

--- a/src/helpers/interfaces.ts
+++ b/src/helpers/interfaces.ts
@@ -22,6 +22,8 @@ export interface IExtraLifeUser {
     numIncentives: number;
     isCustomAvatarImage: boolean;
     URL: string;
+    cacheTag: string;
+    lastModifiedUTC: string;
 }
 
 export interface IExtraLifeMilestone {


### PR DESCRIPTION
Per the instructions on the DonorDrive API, we can send the ETag value and get a 304 if the contents have not changed.

https://github.com/DonorDrive/PublicAPI/blob/master/overview.md#status-codes

I've added the `cacheTag` and `lastModifiedUTC` to the response of getUserInfo.  Additionally, an optional `cacheTag` that will cause a rejected promise with "Not Modified" if the cache hits.

Additionally, `res.json()` is a promise, so the previous code was unable to access or modify the return value.  This also meanth that it would never load the teamURL.  Instead of restoring the teamURL functionality, I removed it so that we don't add additional API calls without explict ask.